### PR TITLE
Update Coordinate Conversion geometry Service

### DIFF
--- a/CoordinateConversion/CoordinateControl.js
+++ b/CoordinateConversion/CoordinateControl.js
@@ -138,13 +138,10 @@ define([
          **/
         setConfig: function () {
           this.util = new Util({
-            appConfig: this.parentWidget.config
+            appConfig: this.parentWidget.appConfig
           });
 
-          var geomsrvcurl = this.parentWidget.config.coordinateconversion.geometryService.url ||
-            'http://pscltags1.eastus.cloudapp.azure.com/arcgis/rest/services/Utilities/Geometry/GeometryServer';
-
-          this.geomsrvc = new EsriGeometryService(geomsrvcurl);
+          this.geomsrvc = this.util.geomService;
 
           this.zoomScale = this.parentWidget.config.coordinateconversion.zoomScale || 50000;
 

--- a/CoordinateConversion/config.json
+++ b/CoordinateConversion/config.json
@@ -1,9 +1,6 @@
 {
   "coordinateconversion": {
       "zoomScale": 50000,
-      "initialCoords": ["DDM", "DMS", "MGRS", "UTM"],
-      "geometryService": {
-          "url": "http://sampleserver6.arcgisonline.com/arcgis/rest/services/Utilities/Geometry/GeometryServer"
-      }
+      "initialCoords": ["DDM", "DMS", "MGRS", "UTM"]
   }
 }

--- a/CoordinateConversion/manifest.json
+++ b/CoordinateConversion/manifest.json
@@ -1,5 +1,6 @@
 {
   "name": "CoordinateConversion",
+  "label": "Coordinate Conversion",
   "platform": "HTML",
   "version": "1.4",
   "wabVersion": "1.4",

--- a/CoordinateConversion/nls/strings.js
+++ b/CoordinateConversion/nls/strings.js
@@ -1,4 +1,5 @@
 define({
   root: ({
+    _widgetLabel: "Coordinate Conversion"
   }),
 });

--- a/CoordinateConversion/setting/Setting.html
+++ b/CoordinateConversion/setting/Setting.html
@@ -1,8 +1,8 @@
 <div style="width: 100%; height: 100%">
   <table class="setting-table input-table" cellspacing="0">
     <tbody>
-	
-	
+
+
       <tr class='row'>
         <td class="first">
           <span class="inputs-label">Zoom Scale</span>
@@ -39,7 +39,7 @@
       </tr>
       <tr class="spacer"></tr>
       <tr class='row'>
-        <td class="first">
+        <!-- <td class="first">
           <span class="inputs-label">Geometry Service</span>
         </td>
         <td class="second">
@@ -47,7 +47,7 @@
         </td>
         <td class="third">
           <div class="help-icon"></div>
-        </td>
+        </td> -->
       </tr>
     </tbody>
   </table>

--- a/CoordinateConversion/setting/Setting.js
+++ b/CoordinateConversion/setting/Setting.js
@@ -39,7 +39,7 @@ define([
     startup: function () {
       this.inherited(arguments);
 
-      this.geoservice.set('value', this.config.coordinateconversion.geometryService.url);
+      //this.geoservice.set('value', this.config.coordinateconversion.geometryService.url);
       this.notationSelect.set('value', this.config.coordinateconversion.initialCoords);
       this.scale.set('value', this.config.coordinateconversion.zoomScale);
       this.setConfig(this.config);
@@ -56,7 +56,7 @@ define([
      *
      **/
     getConfig: function () {
-      this.config.coordinateconversion.geometryService.url = this.geoservice.get('value');
+      //this.config.coordinateconversion.geometryService.url = this.geoservice.get('value');
       this.config.coordinateconversion.initialCoords= this.notationSelect.get('value');
       this.config.coordinateconversion.zoomScale = parseFloat(this.scale.value);
       return this.config;

--- a/CoordinateConversion/util.js
+++ b/CoordinateConversion/util.js
@@ -35,9 +35,11 @@ define([
 
         constructor: function (ac) {
             this.appConfig = ac.appConfig;
-            this.geomService = new EsriGeometryService(
-              this.appConfig.coordinateconversion.geometryService.url
-            );
+            var gs = this.appConfig.geometryService;
+            if (!gs) {
+              gs = '//utility.arcgisonline.com/arcgis/rest/services/Geometry/GeometryServer';
+            }
+            this.geomService = new EsriGeometryService(gs);
         },
 
         /**

--- a/DistanceAndDirection/manifest.json
+++ b/DistanceAndDirection/manifest.json
@@ -1,5 +1,6 @@
 {
   "name": "DistanceAndDirection",
+  "label": "Distance and Direction",
   "platform": "HTML",
   "version": "1.4",
   "wabVersion": "1.4",

--- a/DistanceAndDirection/nls/strings.js
+++ b/DistanceAndDirection/nls/strings.js
@@ -1,4 +1,5 @@
 define({
   root: ({
+    _widgetLabel: "Distance and Direction"
   }),
 });


### PR DESCRIPTION
@kgonzago - Kevin, can you take a look at this and review? Thanks.
- Get the geometry service from the default portal location. This will be beneficial in disconnected environments, as users will not need to specifically specify the geometry service for each widget
- fix #56 & #57 to set default widget names with spaces.
